### PR TITLE
Support register variables

### DIFF
--- a/lib/generator.go
+++ b/lib/generator.go
@@ -354,6 +354,8 @@ func rewriteTestNode(n ast.Node, test Test) ast.Node {
 				v.Value = fmt.Sprintf(`"%s"`, test.Path)
 			case `"status"`:
 				v.Value = fmt.Sprintf("%d", test.Res.Status)
+			case `"registerKey"`:
+				v.Value = fmt.Sprintf(`"%s"`, test.Register)
 			}
 		case *ast.Ident:
 			ident = v.Name

--- a/lib/generator.go
+++ b/lib/generator.go
@@ -390,6 +390,11 @@ func rewriteTestNode(n ast.Node, test Test) ast.Node {
 				s = strings.TrimRight(s, `}"`)
 				t := strings.Split(s, ":")
 				v.Value = fmt.Sprintf(`vars["%s"].(%s)`, t[0], t[1])
+			} else if strings.HasPrefix(v.Value, `"$register[`) {
+				s := strings.TrimLeft(v.Value, `"$register[`)
+				s = strings.TrimRight(s, `]"`)
+				t := strings.Split(s, ".")
+				v.Value = fmt.Sprintf(`register["%s"].(map[string]interface{})["%s"].(string)`, t[0], t[1])
 			}
 		}
 		return true

--- a/lib/parser.go
+++ b/lib/parser.go
@@ -258,6 +258,11 @@ func convertToTest(t map[interface{}]interface{}) (Test, error) {
 		return Test{}, err
 	}
 
+	register := ""
+	if t["register"] != nil {
+		register = t["register"].(string)
+	}
+
 	return Test{
 		APIVersions: apiVersions,
 		Path:        t["path"].(string),
@@ -265,6 +270,7 @@ func convertToTest(t map[interface{}]interface{}) (Test, error) {
 		Req:         req,
 		Res:         res,
 		Vars:        vars,
+		Register:    register,
 	}, nil
 }
 

--- a/lib/parser_test.go
+++ b/lib/parser_test.go
@@ -43,6 +43,10 @@ func TestParseTestFuncPerAPIVersion(t *testing.T) {
 	if test.Vars["foo"] != "bar" {
 		t.Fatal(`test.Vars["foo"] should be bar`)
 	}
+
+	if test.Register != "baz" {
+		t.Fatal("register should be baz")
+	}
 }
 
 func TestParseTestPerAPIVersion(t *testing.T) {

--- a/lib/types.go
+++ b/lib/types.go
@@ -35,6 +35,7 @@ type Test struct {
 	Req         Req
 	Res         Res
 	Vars        map[string]interface{}
+	Register    string
 }
 
 // Subtests is a group of Subtest

--- a/lib/yaml_for_test.go
+++ b/lib/yaml_for_test.go
@@ -27,6 +27,7 @@ var yamlTestFuncPerAPIVersion = `
           foo: bar
       vars:
          foo: bar
+      register: baz
 `
 
 var yamlTestPerAPIVersion = `


### PR DESCRIPTION
#7 を実装してみました。

以下のようにYAMLで書きます。

```yaml
- name: TestPostAndCreatePost
  routerFunc: github.com/aktsk/atgen/example.getRouter
  apiVersions:
    - v1
  tests:
    - path: /{apiVersion}/people/3
      method: post
      req:
        params:
          firstname: Jane
          lastname: Doe
      res:
        status: 200
      register: jane # register["jane"] にレスポンスボディのJSONをUnmarshalした値をつっこむ
    - path: /{apiVersion}/people/3/posts
      method: post
      headers:
         authorization: $register[jane.apiKey] # register["jane"]["apiKey"] の値を使用する
      params:
         title: "foo"
         body: "bar"
      res:
        status: 200
```

テンプレートコード中には以下の様に記述する必要があります。

```go
func TestTeamplate(t *testing.T) {
    // Test関数の最初の方で記述
    register := map[string]interface{}{}

    // テストを実行するブロック
    {
        ...
        // テストの最後の方で、レスポンスボディをUnmarshalしたものを格納
        // registerKey は YAML で定義した値に置換される
        register["registerKey"] = params
    }
}
```

#7 で示されたYAMLと微妙に違うのは、以下の理由によります。

- #7 では `register: jane # jane に response のオブジェクトを格納する` とあるのですが、基本的にはレスポンスボディの内容を格納できれば十分なはずなので、実装を簡単にするためにも、responseオブジェクトではなくレスポンスボディをJSON.Unmarshal()した値を格納しています。
- #7 ではregisterした値を `{jane.params.apiKey}` で使用していますが、`{ }`はYAMLではハッシュ(正確にはマッピング)と解釈されるので、`$register[jane.apiKey]`としました。（頭の`$`はなくてもいいかも、とも思ってます。）

以下の様な制限がありますが、Subierでのユースケースであればこれで十分、ということで、実装を単純にするために、このようにしています。

- registerに格納できるのは `map[string]interface{}` に限定しています。
- `$register[foo.bar]`とYAMLに書かれてるものは、Goのコードでは`register["foo"].(map[string]interface{})["bar"].(string)`と変換されます。なのでstringしか想定していません。

また、現在の実装では`vars`という変数を格納庫にして好きな値を入れられるようになっていて、YAMLで `${apiKey:string}` と書くとGo側では`vars["apiKey"].(string)`という形で取り出せるのですが、registerと似たような機能で、しかもYAMLの書き方が違うので、このPRとは別に、もっとわかりやすく、統一的に扱えるような修正を入れたいと思います。

@sachaos 明日お会いできたら、詳細お話しさせてください！