### PR TITLE
Disable golint temporary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,14 @@ REVISION := $(shell git rev-parse --short HEAD)
 all: build
 
 setup:
-	go get github.com/golang/lint/golint
 	go get golang.org/x/tools/cmd/goimports
 	go get github.com/tcnksm/ghr
 	go get github.com/Songmu/goxz/cmd/goxz
 	go get github.com/motemen/gobump/cmd/gobump
 
-test: lint
+test:
 	go test ./lib
 	go test -race ./lib
-
-lint: setup
-	golint ./...
 
 fmt: setup
 	goimports -w .


### PR DESCRIPTION
Because this error occurs:

go: github.com/golang/lint@v0.0.0-20190313153728-d0100b6bd8b3: parsing
go.mod: unexpected module path "golang.org/x/lint"

Many issues which report this kind of error, for example
https://github.com/googleapis/google-cloud-go/issues/1359