### PR TITLE
Use go/packages instead of go/loader

### DIFF
--- a/lib/parser.go
+++ b/lib/parser.go
@@ -1,7 +1,6 @@
 package atgen
 
 import (
-	"fmt"
 	"go/types"
 	"io/ioutil"
 	"os"
@@ -10,7 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
-	"golang.org/x/tools/go/loader"
+	"golang.org/x/tools/go/packages"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -45,6 +44,7 @@ func (g *Generator) ParseYaml() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
+
 	program, err := loadUsingPackages(routerFuncs)
 	if err != nil {
 		return errors.WithStack(err)
@@ -124,7 +124,7 @@ func convertToTestFuncs(parsed []map[interface{}]interface{}) (TestFuncs, error)
 	return testFuncs, nil
 }
 
-func loadUsingPackages(routerFuncs []*RouterFunc) (*loader.Program, error) {
+func loadUsingPackages(routerFuncs []*RouterFunc) ([]*packages.Package, error) {
 	packagePaths := []string{"net/http"}
 
 	for _, routerFunc := range routerFuncs {
@@ -133,11 +133,19 @@ func loadUsingPackages(routerFuncs []*RouterFunc) (*loader.Program, error) {
 		}
 	}
 
-	conf := loader.Config{}
-	for _, packagePath := range packagePaths {
-		conf.Import(packagePath)
+	conf := &packages.Config{}
+	pkgs, err := packages.Load(conf, packagePaths...)
+	if err != nil {
+		return nil, errors.WithStack(err)
 	}
-	return conf.Load()
+
+	for _, pkg := range pkgs {
+		if pkg.Errors != nil {
+			return nil, errors.WithStack(pkg.Errors[0])
+		}
+	}
+
+	return pkgs, nil
 }
 
 func usingSamePackage(packagePaths []string, routerFunc *RouterFunc) bool {
@@ -186,16 +194,22 @@ func isRelativePath(path string) bool {
 	return strings.HasPrefix(path, ".")
 }
 
-func validateRouterFuncs(routerFuncs []*RouterFunc, program *loader.Program) error {
-	handlerObj := program.Package("net/http").Pkg.Scope().Lookup("Handler")
-	for _, routerFunc := range routerFuncs {
-		pkg := program.Package(routerFunc.PackagePath)
-		if pkg == nil {
-			return errors.New(fmt.Sprintf("%s is not found in loaded packages", routerFunc.PackagePath))
-		}
-		funcObj := pkg.Pkg.Scope().Lookup(routerFunc.Name)
+func validateRouterFuncs(routerFuncs []*RouterFunc, program []*packages.Package) error {
+	conf := &packages.Config{Mode: packages.LoadAllSyntax}
+	pkgs, err := packages.Load(conf, "net/http")
+	if err != nil {
+		return errors.WithStack(err)
+	}
 
-		err := validateRouterFuncObj(handlerObj, funcObj, routerFunc)
+	handlerObj := pkgs[0].Types.Scope().Lookup("Handler")
+	for _, routerFunc := range routerFuncs {
+		routerPackage, err := packages.Load(conf, routerFunc.PackagePath)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		funcObj := routerPackage[0].Types.Scope().Lookup(routerFunc.Name)
+
+		err = validateRouterFuncObj(handlerObj, funcObj, routerFunc)
 		if err != nil {
 			return err
 		}

--- a/lib/parser.go
+++ b/lib/parser.go
@@ -196,18 +196,14 @@ func isRelativePath(path string) bool {
 
 func validateRouterFuncs(routerFuncs []*RouterFunc, program []*packages.Package) error {
 	conf := &packages.Config{Mode: packages.LoadAllSyntax}
-	pkgs, err := packages.Load(conf, "net/http")
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
-	handlerObj := pkgs[0].Types.Scope().Lookup("Handler")
 	for _, routerFunc := range routerFuncs {
-		routerPackage, err := packages.Load(conf, routerFunc.PackagePath)
+		pkgs, err := packages.Load(conf, "net/http", routerFunc.PackagePath)
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		funcObj := routerPackage[0].Types.Scope().Lookup(routerFunc.Name)
+
+		handlerObj := pkgs[0].Types.Scope().Lookup("Handler")
+		funcObj := pkgs[1].Types.Scope().Lookup(routerFunc.Name)
 
 		err = validateRouterFuncObj(handlerObj, funcObj, routerFunc)
 		if err != nil {

--- a/lib/types.go
+++ b/lib/types.go
@@ -1,6 +1,6 @@
 package atgen
 
-import "golang.org/x/tools/go/loader"
+import "golang.org/x/tools/go/packages"
 
 // Generator is the type for code generator
 type Generator struct {
@@ -11,7 +11,7 @@ type Generator struct {
 	RouterFuncs            []*RouterFunc
 	TestFuncs              TestFuncs
 	TestFuncsPerAPIVersion map[string]TestFuncs
-	Program                *loader.Program
+	Program                []*packages.Package
 }
 
 // TestFuncs is a group of TestFunc


### PR DESCRIPTION
Because go/loader(precisely go/builder which go/loader depends on) will not support go modules.

Ref #9