### PR TITLE
Cache results of packges.Load() to shorten execution time

### DIFF
--- a/lib/parser.go
+++ b/lib/parser.go
@@ -193,7 +193,7 @@ func isRelativePath(path string) bool {
 	return strings.HasPrefix(path, ".")
 }
 
-var packageCache map[string][]*packages.Package = map[string][]*packages.Package{}
+var packageCache = map[string][]*packages.Package{}
 
 func validateRouterFuncs(routerFuncs []*RouterFunc, program []*packages.Package) error {
 	conf := &packages.Config{Mode: packages.LoadAllSyntax}

--- a/lib/parser.go
+++ b/lib/parser.go
@@ -193,18 +193,25 @@ func isRelativePath(path string) bool {
 	return strings.HasPrefix(path, ".")
 }
 
+var packageCache map[string][]*packages.Package = map[string][]*packages.Package{}
+
 func validateRouterFuncs(routerFuncs []*RouterFunc, program []*packages.Package) error {
 	conf := &packages.Config{Mode: packages.LoadAllSyntax}
 	for _, routerFunc := range routerFuncs {
-		pkgs, err := packages.Load(conf, "net/http", routerFunc.PackagePath)
-		if err != nil {
-			return errors.WithStack(err)
+		path := routerFunc.PackagePath
+		if packageCache[path] == nil {
+			pkgs, err := packages.Load(conf, "net/http", path)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			packageCache[path] = pkgs
 		}
 
+		pkgs := packageCache[path]
 		handlerObj := pkgs[0].Types.Scope().Lookup("Handler")
 		funcObj := pkgs[1].Types.Scope().Lookup(routerFunc.Name)
 
-		err = validateRouterFuncObj(handlerObj, funcObj, routerFunc)
+		err := validateRouterFuncObj(handlerObj, funcObj, routerFunc)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Subierのテスト生成に1分以上時間がかかり、調べてみたところ`validateRouterFuncs()`内の`packages.Load(conf, "net/http", routerFunc.PackagePath)`が何度も実行されていて遅い、ということがわかったので、実行結果を`routerFunc.PackagePath`毎にキャッシュして使い回すようにしてみました。

修正前

```
$ time atgen gen -t appengine/app/tests/temp：late -o appengine/app/tests/generated
atgen gen -t appengine/app/tests/template -o  146.06s user 21.47s system 251% cpu 1:06.71 total
```

修正後

```
$ time atgen gen -t appengine/app/tests/template -o appengine/app/tests/generated
atgen gen -t appengine/app/tests/template -o  5.60s user 2.07s system 215% cpu 3.556 total
```

@sachaos 時間ありましたらざっと見ておいていただけると助かります:pray: