### PR TITLE
Add Atgen prefix before functions and variables replaced by atgen

### DIFF
--- a/example/template/template_test.go
+++ b/example/template/template_test.go
@@ -8,47 +8,47 @@ import (
 	"testing"
 )
 
-// TestFunc block
+// Atgen TestFunc block
 // You must write above comment to point this is a test function.
 func TestTeamplate(t *testing.T) {
-	r := RouterFunc()
+	r := AtgenRouterFunc()
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
 	client := new(http.Client)
 
-	// Test block
+	// Atgen Test block
 	// You must write above comment to point this is a test code template
 	// Atgen generates test code from this block.
 	{
 
 		// This is replaced with req.params defined in YAML
-		reqParams := map[string]interface{}{}
-		reqBody, _ := json.Marshal(reqParams)
+		atgenReqParams := map[string]interface{}{}
+		reqBody, _ := json.Marshal(atgenReqParams)
 
 		req, _ := http.NewRequest(
-			"Method",      // This is replaced with method defined in YAML
-			ts.URL+"Path", // This is replaced with path defined in YAML
+			"AtgenMethod",      // This is replaced with method defined in YAML
+			ts.URL+"AtgenPath", // This is replaced with path defined in YAML
 			bytes.NewReader(reqBody),
 		)
 
 		// This is replaced with req.headers defined in YAML
-		reqHeaders := map[string]interface{}{}
-		for h, v := range reqHeaders {
+		atgenReqHeaders := map[string]interface{}{}
+		for h, v := range atgenReqHeaders {
 			req.Header.Set(h, v)
 		}
 
 		res, _ := client.Do(req)
 
-		// "status" is replaced with res.status defined in YAML
-		if res.StatusCode != "status" {
+		// "atgenStatus" is replaced with res.status defined in YAML
+		if res.StatusCode != "atgenStatus" {
 			t.Log(res.Body)
 			t.Errorf("Expected status code should be %d, but actually %d", "status", res.StatusCode)
 		}
 
 		// This is replaced with req.headers defined in YAML
-		resHeaders := map[string]string{}
-		for h, v := range resHeaders {
+		atgenResHeaders := map[string]string{}
+		for h, v := range atgenResHeaders {
 			actually := res.Header.Get(h)
 			if actually != v {
 				t.Errorf("%v header should be %v, but actually %v", h, v, actually)
@@ -68,8 +68,8 @@ func TestTeamplate(t *testing.T) {
 		}
 
 		// This is replaced with req.params defined in YAML
-		resParams := map[string]interface{}{}
-		for k, v := range resParams {
+		atgenResParams := map[string]interface{}{}
+		for k, v := range atgenResParams {
 			if params[k] != v {
 				t.Fatalf("params[%#v] should be %#v, but %#v", k, v, params[k])
 			}

--- a/lib/generator.go
+++ b/lib/generator.go
@@ -20,7 +20,7 @@ import (
 )
 
 // RouterFuncName is function name to be replaced
-const RouterFuncName = "RouterFunc"
+const RouterFuncName = "AtgenRouterFunc"
 
 // Generate generates code and write to files
 func (g *Generator) Generate() error {
@@ -77,11 +77,11 @@ func (g *Generator) generateTestFuncs(version string, testFuncs TestFuncs, w io.
 	cmap := ast.NewCommentMap(fset, f, f.Comments)
 	for node, cgroups := range cmap {
 		for _, cgroup := range cgroups {
-			if strings.Contains(cgroup.Text(), "TestFunc block") {
+			if strings.Contains(cgroup.Text(), "Atgen TestFunc block") {
 				testFuncNode = node
-			} else if strings.Contains(cgroup.Text(), "Test block") {
+			} else if strings.Contains(cgroup.Text(), "Atgen Test block") {
 				testNode = node
-			} else if strings.Contains(cgroup.Text(), "Subtest block") {
+			} else if strings.Contains(cgroup.Text(), "Atgen Subtest block") {
 				subtestNode = node
 			}
 		}
@@ -130,7 +130,7 @@ func (g *Generator) generateTestFuncs(version string, testFuncs TestFuncs, w io.
 						switch v := cr.Node().(type) {
 						case *ast.BasicLit:
 							switch v.Value {
-							case `"SubtestName"`:
+							case `"AtgenSubtestName"`:
 								v.Value = fmt.Sprintf(`"%s"`, subtest.Name)
 							}
 						}
@@ -353,31 +353,31 @@ func rewriteTestNode(n ast.Node, test Test) ast.Node {
 		switch v := cr.Node().(type) {
 		case *ast.BasicLit:
 			switch v.Value {
-			case `"Method"`:
+			case `"AtgenMethod"`:
 				v.Value = fmt.Sprintf(`"%s"`, strings.ToUpper(test.Method))
-			case `"Path"`:
+			case `"AtgenPath"`:
 				v.Value = fmt.Sprintf(`"%s"`, test.Path)
-			case `"status"`:
+			case `"atgenStatus"`:
 				v.Value = fmt.Sprintf("%d", test.Res.Status)
-			case `"registerKey"`:
+			case `"atgenRegisterKey"`:
 				v.Value = fmt.Sprintf(`"%s"`, test.Register)
 			}
 		case *ast.Ident:
 			ident = v.Name
 		case *ast.CompositeLit:
-			if ident == "reqHeaders" {
+			if ident == "atgenReqHeaders" {
 				h, _ := parser.ParseExpr(fmt.Sprintf("%#v", test.Req.Headers))
 				cr.Replace(h)
-			} else if ident == "reqParams" {
+			} else if ident == "atgenReqParams" {
 				p, _ := parser.ParseExpr(fmt.Sprintf("%#v", test.Req.Params))
 				cr.Replace(p)
-			} else if ident == "resHeaders" {
+			} else if ident == "atgenResHeaders" {
 				h, _ := parser.ParseExpr(fmt.Sprintf("%#v", test.Res.Headers))
 				cr.Replace(h)
-			} else if ident == "resParams" {
+			} else if ident == "atgenResParams" {
 				p, _ := parser.ParseExpr(fmt.Sprintf("%#v", test.Res.Params))
 				cr.Replace(p)
-			} else if ident == "testVars" {
+			} else if ident == "atgenTestVars" {
 				h, _ := parser.ParseExpr(fmt.Sprintf("%#v", test.Vars))
 				cr.Replace(h)
 			}
@@ -395,11 +395,11 @@ func rewriteTestNode(n ast.Node, test Test) ast.Node {
 				s = strings.TrimSuffix(s, `}"`)
 				t := strings.Split(s, ":")
 				v.Value = fmt.Sprintf(`vars["%s"].(%s)`, t[0], t[1])
-			} else if strings.HasPrefix(v.Value, `"$register[`) {
-				s := strings.TrimPrefix(v.Value, `"$register[`)
+			} else if strings.HasPrefix(v.Value, `"$atgenRegister[`) {
+				s := strings.TrimPrefix(v.Value, `"$atgenRegister[`)
 				s = strings.TrimSuffix(s, `]"`)
 				t := strings.Split(s, ".")
-				v.Value = fmt.Sprintf(`register["%s"].(map[string]interface{})["%s"].(string)`, t[0], t[1])
+				v.Value = fmt.Sprintf(`atgenRegister["%s"].(map[string]interface{})["%s"].(string)`, t[0], t[1])
 			}
 		}
 		return true


### PR DESCRIPTION
## Issue

#16

## What

atgen側で使っている関数名や変数名に `Atgen` もしくは `atgen` prefixをつける。 