### PR TITLE
Change to use format.Node when writing generated code

### DIFF
--- a/lib/generator.go
+++ b/lib/generator.go
@@ -3,8 +3,8 @@ package atgen
 import (
 	"fmt"
 	"go/ast"
+	"go/format"
 	"go/parser"
-	"go/printer"
 	"go/token"
 	"io"
 	"io/ioutil"
@@ -199,9 +199,9 @@ func (g *Generator) generateTestFuncs(version string, testFuncs TestFuncs, w io.
 	}, nil)
 
 	f.Comments = cmap.Filter(f).Comments()
-	printer.Fprint(w, fset, f)
+	err = format.Node(w, fset, f)
 
-	return nil
+	return err
 }
 
 func rewriteSubtestNode(subtest ast.Node, tests []ast.Node) ast.Node {


### PR DESCRIPTION
## What

生成コードをファイルに書き込む処理を `printer.Fprint` から `format.Node` に変更する。

## Why

`format.Node` はgofmtと同じフォーマットで書き込んでくれるため。

## References
- [printer - The Go Programming Language](https://golang.org/pkg/go/printer/#Fprint)
- [format - The Go Programming Language](https://golang.org/pkg/go/format/#Node)
